### PR TITLE
Changed to requiring ggbio 1.8.8 because the current 1.10.10 has a minor...

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     GenomicRanges,
     Rsamtools,
     parallel,
-    ggbio (>= 1.10.8),
+    ggbio (>= 1.8.8),
     ggplot2,
     reshape2,
     plyr,


### PR DESCRIPTION
... bug that affects plotCluster(). Using ggbio 1.8.8 while the maintainer of ggbio to fixes it.
